### PR TITLE
Remove square brackets from getInputHTML

### DIFF
--- a/src/fields/DynamicOptionsField.php
+++ b/src/fields/DynamicOptionsField.php
@@ -124,7 +124,7 @@ class DynamicOptionsField extends Field
 		$variables['element'] = $element;
 		//$variables['model'] = $this->model;
 
-		$options = Json::decode('['.Craft::$app->getView()->renderString($this->json, $variables).']', true);
+		$options = Json::decode(Craft::$app->getView()->renderString($this->json, $variables), true);
 		Craft::$app->getView()->setTemplateMode($oldMode);
 
         // Variables to pass down to our field JavaScript to let it namespace properly


### PR DESCRIPTION
It might pay to leave it up to the twig being passed through to have the square brackets.
It's much more difficult to remove [] in twig than it is to add them e.g. json_encode.

For example:
```twig
    {% set myArray = [] %}
    {% for item in items %}
        {% set myArray = myArray|merge([{
            'label': item.label,
            'value': item.id
        }]) %}
    {% endfor %}
    {{ myArray | json_encode() | raw }}
```